### PR TITLE
Feature/objects 927

### DIFF
--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -7,13 +7,9 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-
 import javax.annotation.PostConstruct;
 
 import lombok.extern.slf4j.Slf4j;
-import net.smartcosmos.cluster.auth.domain.UserResponse;
-import net.smartcosmos.security.SecurityResourceProperties;
-import net.smartcosmos.security.user.SmartCosmosCachedUser;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -43,9 +39,10 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 
-/**
- * @author voor
- */
+import net.smartcosmos.cluster.auth.domain.UserResponse;
+import net.smartcosmos.security.SecurityResourceProperties;
+import net.smartcosmos.security.user.SmartCosmosCachedUser;
+
 @Slf4j
 @Service
 @Profile("!test")
@@ -122,7 +119,7 @@ public class SmartCosmosAuthenticationProvider
                                      UsernamePasswordAuthenticationToken authentication) throws InternalAuthenticationServiceException {
         try {
             return this.restTemplate
-                .exchange(userDetailsServerLocationUri + "/{username}",
+                .exchange(userDetailsServerLocationUri + "/authenticate",
                     HttpMethod.POST, new HttpEntity<Object>(authentication),
                     UserResponse.class, username)
                 .getBody();
@@ -175,8 +172,8 @@ public class SmartCosmosAuthenticationProvider
         log.info("Received response of: {}", userResponse);
 
         final SmartCosmosCachedUser user = new SmartCosmosCachedUser(
-                userResponse.getAccountUrn(), userResponse.getUserUrn(), userResponse.getUsername(),
-                userResponse.getPasswordHash(), userResponse.getRoles().stream()
+                userResponse.getTenantUrn(), userResponse.getUserUrn(), userResponse.getUsername(),
+                userResponse.getPasswordHash(), userResponse.getAuthorities().stream()
                         .map(SimpleGrantedAuthority::new).collect(Collectors.toSet()));
 
         users.put(userResponse.getUsername(), user);

--- a/src/main/java/net/smartcosmos/cluster/auth/domain/UserResponse.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/domain/UserResponse.java
@@ -1,11 +1,11 @@
 package net.smartcosmos.cluster.auth.domain;
 
+import java.util.List;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import java.util.List;
 
 /**
  * This is the response from the User Details Service that will contain the necessary
@@ -21,7 +21,7 @@ import java.util.List;
 @ToString(exclude = "passwordHash")
 public class UserResponse {
 
-    private String accountUrn;
+    private String tenantUrn;
 
     private String userUrn;
 
@@ -29,5 +29,5 @@ public class UserResponse {
 
     private String passwordHash;
 
-    private List<String> roles;
+    private List<String> authorities;
 }


### PR DESCRIPTION
### What changes were proposed in this pull request?
- renames `roles` to `authorities`
- changes the endpoint to get the authorities to `/authenticate`
### How is this patch documented?

Code.
### How was this patch tested?

Manually in Postman.
#### Depends On

`POST /authenticate` endpoint added in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-details-service/pull/7
