### PR TITLE
Handle user details service error responses and improve logging

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -8,7 +8,8 @@ No new features are added in this release.
 
 === Bugfixes & Improvements
 
-* PROFILES-667: add zipkin starter for distributed tracing
+* PROFILES-667 Add zipkin starter for distributed tracing
+* OBJECTS-1028 Improve Handling of User Details Errors in Auth Server
 
 == Release 3.0.0 (August 12, 2016)
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The error handling and logging for requests to the user details service is improved to account for improved responses from the use details services.

In particular, it differentiates between invalid client and user credential now.

If the HTTP Basic Authentication for the user details service is incorrect, the following response will be returned:

```
401 Unauthorized

{
  "error": "invalid_client",
  "error_description": "Invalid client credentials for user details service"
}
```

In case of invalid user credentials (submitted in the query parameters), the error response will be:

```
400 Bad Request

{
  "error": "invalid_grant",
  "error_description": "Invalid username or password"
}
```

**Important:** In this case the HTTP status code changed, because the previous _401 Unauthorized_ didn't match the spec for bad credentials responses, as mentioned in a Spring code comment: [ResourceOwnerPasswordTokenGranter:78](https://github.com/spring-projects/spring-security-oauth/blob/master/spring-security-oauth2/src/main/java/org/springframework/security/oauth2/provider/password/ResourceOwnerPasswordTokenGranter.java#L78)

This means, other services or filters that called the Auth Server to get a token potentially need to be updated, if they explicitly expected the actually wrong _401 Unauthorized_ response in case of invalid user credentials.
### How is this patch documented?

Code and code comments.
### How was this patch tested?

manually in Postman
#### Depends On

Even though these changes do not depend on other changes, they relate to:
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-details-devkit/pull/6
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-user-details-stormpath/pull/17
