### PR TITLE
Fix exceptions to return 500 Internal Server Error

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -10,6 +10,7 @@ No new features are added in this release.
 
 * PROFILES-667 Add zipkin starter for distributed tracing
 * OBJECTS-1028 Improve Handling of User Details Errors in Auth Server
+* OBJECTS-1030 Auth server returns incorrect error responses
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -26,7 +26,6 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.InterceptingClientHttpRequestFactory;
 import org.springframework.security.authentication.BadCredentialsException;
-import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.authentication.dao.AbstractUserDetailsAuthenticationProvider;
 import org.springframework.security.core.AuthenticationException;
@@ -158,7 +157,7 @@ public class SmartCosmosAuthenticationProvider
             }
         } catch (Exception e) {
             log.debug("Fetching details for user {} with authentication token {} failed: {}", username, authentication, e);
-            throw new InternalAuthenticationServiceException(e.getMessage(), e);
+            throw new RuntimeException(e.getMessage(), e);
         }
     }
 

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -148,10 +148,12 @@ public class SmartCosmosAuthenticationProvider
                     if (!StringUtils.isEmpty(responseMessage)) {
                         // creates an invalid_grant OAuthException further on
                         // see org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter
+                        // also see https://tools.ietf.org/html/rfc6749#section-5.2
                         throw new BadCredentialsException(responseMessage, e);
                     }
                 default:
                     // creates a server_error response further on
+                    // see https://tools.ietf.org/html/rfc6749#section-4.1.2.1
                     throw new RuntimeException(defaultIfBlank(getErrorResponseMessage(e), e.getMessage()), e);
             }
         } catch (Exception e) {

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -150,14 +150,9 @@ public class SmartCosmosAuthenticationProvider
                         // see org.springframework.security.oauth2.provider.password.ResourceOwnerPasswordTokenGranter
                         throw new BadCredentialsException(responseMessage, e);
                     }
-                    // creates an unauthorized response further on
-                    throw new InternalAuthenticationServiceException(e.getMessage(), e);
-                case INTERNAL_SERVER_ERROR:
-                    // creates a server_error response further on
-                    throw new RuntimeException(defaultIfBlank(getErrorResponseMessage(e), e.getMessage()), e);
                 default:
                     // creates a server_error response further on
-                    throw new RuntimeException(e.getMessage(), e);
+                    throw new RuntimeException(defaultIfBlank(getErrorResponseMessage(e), e.getMessage()), e);
             }
         } catch (Exception e) {
             log.debug("Fetching details for user {} with authentication token {} failed: {}", username, authentication, e);


### PR DESCRIPTION
### What changes were proposed in this pull request?

Previously, the service was returning _401 Unauthorized_ even when there was nothing wrong with the user credentials, but the service credentials did not match the configuration.

This is now changed to return a message like the following:

```
500 Internal Server Error

{
  "error": "server_error",
  "error_description": "Service not properly configured to use credentials"
}
```

Similarly, all other HTTP errors coming from the user details service will result in similar `server_error` responses, as long as they aren't related to bad user credentials.

The intention behind this is to avoid conflicts with the [OAuth 2.0 specification (RFC-6749)](https://tools.ietf.org/html/rfc6749) that explicitly mentions the following HTTP status codes:
- HTTP 200 OK: successful access token request ([section 4.3.3](https://tools.ietf.org/html/rfc6749#section-4.3.3))
- HTTP 400 Bad Request: general error responses, including specified JSON fields ([section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2))
- HTTP 401 Unauthorized: specific status code for `{ "error": "invalid_client" }` responses, that are intended for authorization of a client with `grant_type=client_credentials` ([section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2), [section 4.4.2](https://tools.ietf.org/html/rfc6749#section-4.4.2))
### How is this patch documented?
- Code
- Code comments
### How was this patch tested?

manually in Postman
#### Depends On

Nothing.
