### PR TITLE
Change RestTemplate for SmartCosmosAuthenticationProvider to be a Bean

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@ No new features are added in this release.
 * PROFILES-667 Add zipkin starter for distributed tracing
 * OBJECTS-1028 Improve Handling of User Details Errors in Auth Server
 * OBJECTS-1030 Auth server returns incorrect error responses
+* OBJECTS-1043 Use RestTemplate bean to allow for distributed tracing
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/src/main/java/net/smartcosmos/cluster/auth/config/RestTemplateConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/config/RestTemplateConfiguration.java
@@ -1,0 +1,70 @@
+package net.smartcosmos.cluster.auth.config;
+
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.Collections;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.ClientHttpRequestExecution;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.client.InterceptingClientHttpRequestFactory;
+import org.springframework.util.Base64Utils;
+import org.springframework.web.client.RestTemplate;
+
+import net.smartcosmos.security.SecurityResourceProperties;
+
+import static org.apache.commons.lang.CharEncoding.UTF_8;
+import static org.apache.http.client.config.AuthSchemes.BASIC;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    @Bean
+    @Autowired
+    public RestTemplate userDetailsRestTemplate(
+        RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
+        SecurityResourceProperties securityResourceProperties) {
+
+        final String name = securityResourceProperties.getUserDetails()
+            .getUser()
+            .getName();
+        final String password = securityResourceProperties.getUserDetails()
+            .getUser()
+            .getPassword();
+
+        List<ClientHttpRequestInterceptor> interceptors = Collections.singletonList(new BasicAuthorizationInterceptor(
+            name,
+            password));
+
+        return new RestTemplate(new InterceptingClientHttpRequestFactory(ribbonClientHttpRequestFactory, interceptors));
+    }
+
+    private static class BasicAuthorizationInterceptor implements ClientHttpRequestInterceptor {
+
+        private final String username;
+        private final String password;
+
+        BasicAuthorizationInterceptor(String username, String password) {
+
+            this.username = username;
+            this.password = (password == null ? "" : password);
+        }
+
+        @Override
+        public ClientHttpResponse intercept(HttpRequest request, byte[] body, ClientHttpRequestExecution execution) throws IOException {
+
+            String token = Base64Utils.encodeToString((this.username + ":" + this.password).getBytes(Charset.forName(UTF_8)));
+            request.getHeaders()
+                .add(HttpHeaders.AUTHORIZATION, BASIC + " " + token);
+
+            return execution.execute(request, body);
+        }
+    }
+}

--- a/src/test/java/net/smartcosmos/cluster/auth/TestSmartCosmosAuthenticationProvider.java
+++ b/src/test/java/net/smartcosmos/cluster/auth/TestSmartCosmosAuthenticationProvider.java
@@ -1,18 +1,19 @@
 package net.smartcosmos.cluster.auth;
 
-import net.smartcosmos.cluster.auth.domain.UserResponse;
-import net.smartcosmos.security.SecurityResourceProperties;
+import java.util.Arrays;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
 import org.springframework.context.annotation.Profile;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
 
-import java.util.Arrays;
+import net.smartcosmos.cluster.auth.domain.UserResponse;
+import net.smartcosmos.security.SecurityResourceProperties;
 
 /**
  * @author voor
@@ -25,11 +26,11 @@ public class TestSmartCosmosAuthenticationProvider
 
     @Autowired
     public TestSmartCosmosAuthenticationProvider(
-            RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
-            SecurityResourceProperties securityResourceProperties,
-            PasswordEncoder passwordEncoder) {
-        super(ribbonClientHttpRequestFactory, securityResourceProperties,
-                passwordEncoder);
+        SecurityResourceProperties securityResourceProperties,
+        PasswordEncoder passwordEncoder,
+        RestTemplate restTemplate) {
+
+        super(securityResourceProperties, passwordEncoder, restTemplate);
     }
 
     @Override


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change turns the `RestTemplate` used in `SmartCosmosAuthenticationProvider` to send out User Details requests into a `@Bean`.

This will enable Spring to manage it, which allows for distributed tracing using Zipkin.
### How is this patch documented?

Code.
### How was this patch tested?
- existing unit tests pass
- manually using Postman
#### Depends On

Nothing.
