### PR TITLE
add @EnableSmartCosmosMonitoring

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.0.0</version>
+        <version>3.0.1-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
     <artifactId>smartcosmos-auth-server</artifactId>
@@ -40,6 +40,10 @@
         <dependency>
             <groupId>net.smartcosmos</groupId>
             <artifactId>smartcosmos-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework-monitoring</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
@@ -1,12 +1,10 @@
 package net.smartcosmos.cluster.auth;
 
+import java.security.KeyPair;
+import javax.servlet.Filter;
+
 import lombok.extern.slf4j.Slf4j;
-import net.smartcosmos.cluster.auth.filter.CsrfHeaderFilter;
-import net.smartcosmos.cluster.auth.handlers.AuthUnauthorizedEntryPoint;
-import net.smartcosmos.security.SecurityResourceProperties;
-import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
-import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
-import net.smartcosmos.security.user.SmartCosmosUserAuthenticationConverter;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
@@ -48,8 +46,13 @@ import org.springframework.web.bind.annotation.SessionAttributes;
 import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
-import javax.servlet.Filter;
-import java.security.KeyPair;
+import net.smartcosmos.annotation.EnableSmartCosmosMonitoring;
+import net.smartcosmos.cluster.auth.filter.CsrfHeaderFilter;
+import net.smartcosmos.cluster.auth.handlers.AuthUnauthorizedEntryPoint;
+import net.smartcosmos.security.SecurityResourceProperties;
+import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
+import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
+import net.smartcosmos.security.user.SmartCosmosUserAuthenticationConverter;
 
 /**
  * @author voor
@@ -59,6 +62,7 @@ import java.security.KeyPair;
 @SessionAttributes("authorizationRequest")
 @Slf4j
 @EnableDiscoveryClient
+@EnableSmartCosmosMonitoring
 public class AuthServerApplication extends WebMvcConfigurerAdapter {
 
     public static void main(String[] args) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds `@EnableSmartCosmosMonitoring` annotation to register `/prometheus` metrics endpoint
### How is this patch documented?

Code
### How was this patch tested?

manual service start:

```
2016-10-18 15:27:52.600  INFO [smartcosmos-auth-server,,,] 31108 --- [           main] o.s.b.a.e.mvc.EndpointHandlerMapping     : Mapped "{[/prometheus || /prometheus.json],methods=[GET],produces=[application/json]}" onto public java.lang.Object org.springframework.boot.actuate.endpoint.mvc.EndpointMvcAdapter.invoke()
```
#### Depends On

Nothing.
