### PR TITLE
cached user timeout pushed to auth-server config smartcosmos.security…

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -12,7 +12,7 @@ No new features are added in this release.
 * OBJECTS-1028 Improve Handling of User Details Errors in Auth Server
 * OBJECTS-1030 Auth server returns incorrect error responses
 * OBJECTS-1043 Use RestTemplate bean to allow for distributed tracing
-
+* OBJECTS-1053 Move user cache timeout to auth server configuration
 == Release 3.0.0 (August 12, 2016)
 
 Initial release.


### PR DESCRIPTION
What changes were proposed in this pull request?

Moves cached user timeout to auth server configuration element 
smartcosmos.security.resource.cachedUserKeepAliveSecs: 300

Default is 300, as it was hardcoded before in SmartCosmosCachedUser.java

How is this patch documented?

Source, auth-server config

How was this patch tested?

Debugger, postman

Depends On

https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/207
