### PR TITLE
Bugfix/objects 1112

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,12 +1,14 @@
 = SMART COSMOS Authentication Server Release Notes
 
-== UNRELEASED
+== Release 3.0.2 (November 21, 2016)
 
 === New Features
 
 No new features are added in this release.
 
 === Bugfixes & Improvements
+
+* OBJECTS-1112 Refresh token requests fail with a server error due to an absent password hash
 
 == Release 3.0.1 (November 18, 2016)
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.1.0</version>
+        <version>3.1.1</version>
         <relativePath></relativePath>
     </parent>
     <artifactId>smartcosmos-auth-server</artifactId>

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -266,7 +266,7 @@ public class SmartCosmosAuthenticationProvider
         // Check if we have the user in the cache and it has a password hash, otherwise set empty String to avoid exception in SmartCosmosCachedUser
         // parent class org.springframework.security.core.userdetails.User
         SmartCosmosCachedUser cachedUser = checkedCachedUser(username);
-        String passwordHash = cachedUser != null && isNotBlank(cachedUser.getPassword()) ? cachedUser.getPassword() : "";
+        String passwordHash = getPasswordHashFromCacheForUserResponse(cachedUser, UserResponse userResponse);
 
         final SmartCosmosCachedUser user = new SmartCosmosCachedUser(
             userResponse.getTenantUrn(),
@@ -281,5 +281,18 @@ public class SmartCosmosAuthenticationProvider
         users.put(userResponse.getUsername(), user);
 
         return user;
+    }
+
+    private String getPasswordHashFromCacheForUserResponse(SmartCosmosCachedUser cachedUser, UserResponse userResponse) {
+
+        if (cachedUser != null && isNotBlank(cachedUser.getPassword())
+            && cachedUser.getAccountUrn()
+                .equals(userResponse.getTenantUrn())
+            && cachedUser.getUserUrn()
+                .equals(userResponse.getUserUrn())) {
+
+            return cachedUser.getPassword();
+        }
+        return "";
     }
 }

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -263,16 +263,11 @@ public class SmartCosmosAuthenticationProvider
 
         log.debug("Retrieved user {} from user details service.", userResponse.getUsername());
 
-        // Check if we have the user in the cache and it has a password hash, otherwise set empty String to avoid exception in SmartCosmosCachedUser
-        // parent class org.springframework.security.core.userdetails.User
-        SmartCosmosCachedUser cachedUser = checkedCachedUser(username);
-        String passwordHash = getPasswordHashFromCacheForUserResponse(cachedUser, UserResponse userResponse);
-
         final SmartCosmosCachedUser user = new SmartCosmosCachedUser(
             userResponse.getTenantUrn(),
             userResponse.getUserUrn(),
             userResponse.getUsername(),
-            passwordHash,
+            getPasswordHash(userResponse),
             userResponse.getAuthorities()
                 .stream()
                 .map(SimpleGrantedAuthority::new)
@@ -283,8 +278,18 @@ public class SmartCosmosAuthenticationProvider
         return user;
     }
 
-    private String getPasswordHashFromCacheForUserResponse(SmartCosmosCachedUser cachedUser, UserResponse userResponse) {
+    /**
+     * <p>Gets a password hash for the returned user.</p>
+     * <p>The method checks if the User contained in the {@link UserResponse} is present in the cache, and returns the cached password hash.</p>
+     * <p><b>The response of this method must not be {@code null}</b>, otherwise an exception will be thrown when attempting to instantiate
+     * {@link SmartCosmosCachedUser}.</p>
+     *
+     * @param userResponse the User response from the User Details Service
+     * @return the password hash from the cached user, or an empty String if absent
+     */
+    private String getPasswordHash(UserResponse userResponse) {
 
+        SmartCosmosCachedUser cachedUser = checkedCachedUser(userResponse.getUsername());
         if (cachedUser != null && isNotBlank(cachedUser.getPassword())
             && cachedUser.getAccountUrn()
                 .equals(userResponse.getTenantUrn())


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `GET /active/{username}` may not return a `passwordHash` (i.e., the Stormpath service can't), but if it is attempted to set a `null` password value, instantiation of the `CachedSmartCosmosUser` will fail, so that no new token is returned.

This issue is fixed by checking the already existing cache for a user with the given username. If one is present, its password hash is used, an empty String otherwise.

The code in `org.springframework.security.core.userdetails.User` will check for `null` only:
```
if (((username == null) || "".equals(username)) || (password == null)) {
	throw new IllegalArgumentException("Cannot pass null or empty values to constructor");
}
```

### How is this patch documented?

- Code
- Javadoc

### How was this patch tested?

manually using Postman

#### Depends On

Nothing.