### PR TITLE
Set token expiration based on configuration properties

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -4,7 +4,8 @@
 
 === New Features
 
-OBJECTS-1100: Implement Proper User Cache for Spring
+* OBJECTS-1100: Implement Proper User Cache for Spring
+* allow for refresh and access token expiration configuration
 
 === Bugfixes & Improvements
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
-        <version>3.1.1</version>
+        <version>3.1.2-SNAPSHOT</version>
         <relativePath></relativePath>
     </parent>
     <artifactId>smartcosmos-auth-server</artifactId>

--- a/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
@@ -237,6 +237,8 @@ public class AuthServerApplication extends WebMvcConfigurerAdapter {
                 // TODO This is just here for development purposes.
                 .withClient(securityResourceProperties.getClientId())
                 .secret(securityResourceProperties.getClientSecret())
+                .accessTokenValiditySeconds(securityResourceProperties.getAccessTokenValiditySecs())
+                .refreshTokenValiditySeconds(securityResourceProperties.getRefreshTokenValiditySecs())
                 .authorizedGrantTypes("authorization_code", "refresh_token",
                                       "implicit", "password", "client_credentials")
                 .scopes("read", "write");

--- a/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/AuthServerApplication.java
@@ -51,9 +51,9 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter
 
 import net.smartcosmos.annotation.EnableSmartCosmosMonitoring;
 import net.smartcosmos.cluster.auth.config.AuthServerConfiguration;
+import net.smartcosmos.cluster.auth.config.SecurityResourceProperties;
 import net.smartcosmos.cluster.auth.filter.CsrfHeaderFilter;
 import net.smartcosmos.cluster.auth.handlers.AuthUnauthorizedEntryPoint;
-import net.smartcosmos.security.SecurityResourceProperties;
 import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
 import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
 import net.smartcosmos.security.user.SmartCosmosUserAuthenticationConverter;

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -31,8 +31,8 @@ import org.springframework.web.client.HttpStatusCodeException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
 
+import net.smartcosmos.cluster.auth.config.SecurityResourceProperties;
 import net.smartcosmos.cluster.auth.domain.UserResponse;
-import net.smartcosmos.security.SecurityResourceProperties;
 import net.smartcosmos.security.user.SmartCosmosCachedUser;
 
 import static org.apache.commons.lang.StringUtils.defaultIfBlank;

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -62,7 +62,6 @@ public class SmartCosmosAuthenticationProvider
         this.conversionService = conversionService;
         this.passwordEncoder = passwordEncoder;
         this.restTemplate = restTemplate;
-        this.cachedUserKeepAliveSecs = securityResourceProperties.getCachedUserKeepAliveSecs();
         setUserCache(userCache);
 
         this.userDetailsServerLocationUri = securityResourceProperties.getUserDetails()

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosAuthenticationProvider.java
@@ -47,7 +47,6 @@ public class SmartCosmosAuthenticationProvider
     private final PasswordEncoder passwordEncoder;
     private String userDetailsServerLocationUri;
     private RestTemplate restTemplate;
-    private Integer cachedUserKeepAliveSecs;
     private ConversionService conversionService;
 
     @Autowired

--- a/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosUserCache.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/SmartCosmosUserCache.java
@@ -9,7 +9,7 @@ import org.springframework.cache.Cache;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.cache.SpringCacheBasedUserCache;
 
-import net.smartcosmos.security.SecurityResourceProperties;
+import net.smartcosmos.cluster.auth.config.SecurityResourceProperties;
 import net.smartcosmos.security.user.SmartCosmosCachedUser;
 
 /**

--- a/src/main/java/net/smartcosmos/cluster/auth/config/AuthServerConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/config/AuthServerConfiguration.java
@@ -8,7 +8,6 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.core.userdetails.UserCache;
 
 import net.smartcosmos.cluster.auth.SmartCosmosUserCache;
-import net.smartcosmos.security.SecurityResourceProperties;
 
 /**
  * Configuration for Auth Server.

--- a/src/main/java/net/smartcosmos/cluster/auth/config/RestTemplateConfiguration.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/config/RestTemplateConfiguration.java
@@ -16,8 +16,6 @@ import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.Base64Utils;
 import org.springframework.web.client.RestTemplate;
 
-import net.smartcosmos.security.SecurityResourceProperties;
-
 import static org.apache.commons.lang.CharEncoding.UTF_8;
 import static org.apache.http.client.config.AuthSchemes.BASIC;
 

--- a/src/main/java/net/smartcosmos/cluster/auth/config/SecurityResourceProperties.java
+++ b/src/main/java/net/smartcosmos/cluster/auth/config/SecurityResourceProperties.java
@@ -1,0 +1,52 @@
+package net.smartcosmos.cluster.auth.config;
+
+import lombok.Data;
+
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.core.io.Resource;
+
+/**
+ * Represents the configuration properties for Smart Cosmos Security.
+ *
+ * @author voor
+ */
+@Data
+@ConfigurationProperties("smartcosmos.security.resource")
+public class SecurityResourceProperties {
+
+    public static final int DEFAULT_CACHED_USER_KEEP_ALIVE_SECS = 300;
+    public static final int DEFAULT_ACCESS_TOKEN_VALIDITY_SECS = 60 * 60 * 12; // default 12 hours.
+    public static final int DEFAULT_REFRESH_TOKEN_VALIDITY_SECS = 60 * 60 * 24 * 30; // default 30 days.
+
+    private KeyStoreProperties keystore = new KeyStoreProperties();
+    private UserDetailsProperties userDetails = new UserDetailsProperties();
+
+    private String clientId;
+    private String clientSecret;
+    private Integer cachedUserKeepAliveSecs = DEFAULT_CACHED_USER_KEEP_ALIVE_SECS;
+    private Integer accessTokenValiditySecs = DEFAULT_ACCESS_TOKEN_VALIDITY_SECS;
+    private Integer refreshTokenValiditySecs = DEFAULT_REFRESH_TOKEN_VALIDITY_SECS;
+
+    @Data
+    public class KeyStoreProperties {
+
+        private Resource location;
+        private char[] password;
+        private String keypair;
+        private char[] keypairPassword;
+    }
+
+    @Data
+    public class UserDetailsProperties {
+
+        private SecurityProperties.User user = new SecurityProperties.User();
+        private UserDetailsServerProperties server = new UserDetailsServerProperties();
+    }
+
+    @Data
+    public class UserDetailsServerProperties {
+
+        private String locationUri;
+    }
+}

--- a/src/test/java/net/smartcosmos/cluster/auth/SmartCosmosUserCacheTest.java
+++ b/src/test/java/net/smartcosmos/cluster/auth/SmartCosmosUserCacheTest.java
@@ -5,7 +5,7 @@ import java.util.Collections;
 import org.junit.*;
 import org.springframework.cache.concurrent.ConcurrentMapCache;
 
-import net.smartcosmos.security.SecurityResourceProperties;
+import net.smartcosmos.cluster.auth.config.SecurityResourceProperties;
 import net.smartcosmos.security.user.SmartCosmosCachedUser;
 
 import static org.junit.Assert.*;

--- a/src/test/java/net/smartcosmos/cluster/auth/TestSmartCosmosAuthenticationProvider.java
+++ b/src/test/java/net/smartcosmos/cluster/auth/TestSmartCosmosAuthenticationProvider.java
@@ -14,8 +14,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 
+import net.smartcosmos.cluster.auth.config.SecurityResourceProperties;
 import net.smartcosmos.cluster.auth.domain.UserResponse;
-import net.smartcosmos.security.SecurityResourceProperties;
 
 /**
  * @author voor


### PR DESCRIPTION
### What changes were proposed in this pull request?

Uses the configuration to set the expiration of access tokens and refresh tokens:
```
smartcosmos:
  security:
    resource:
      accessTokenValiditySecs: 43200
      refreshTokenValiditySecs: 2592000
```

By default, we use the same values Spring provides:
- access token expiration: 12 hours
- refresh token expiration: 30 days

### How is this patch documented?

Code

### How was this patch tested?

manually using Postman

#### Depends On

- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/222